### PR TITLE
add search method and refactor utilities

### DIFF
--- a/pacsman/dicom_interface.py
+++ b/pacsman/dicom_interface.py
@@ -1,4 +1,3 @@
-
 from abc import ABC, abstractmethod
 
 from pydicom import datadict
@@ -36,7 +35,23 @@ class DicomInterface(ABC):
     def search_patients(self, search_query, additional_tags=None):
         """
         Uses C-FIND to get patients matching the input (one req for id, one for name)
-        :param patient_input: Search string for either patient name or ID
+        :param search_query: Search string for either patient name or ID
+        :param additional_tags: additional DICOM tags for result datasets
+        :return: List of patient-Level pydicom Datasets, with tags:
+            PatientName
+            PatientID
+            PatientBirthDate
+            PatientStudyIDs (private tag)
+            PatientMostRecentStudyDate (private tag)
+            Any valid DICOM tags in `additional_tags`
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def search_series(self, query_dataset, additional_tags=None):
+        """
+        Uses C-FIND to get patients matching the input (one req for id, one for name)
+        :param query_dataset: Search dataset
         :param additional_tags: additional DICOM tags for result datasets
         :return: List of patient-Level pydicom Datasets, with tags:
             PatientName
@@ -82,12 +97,31 @@ class DicomInterface(ABC):
         """
         raise NotImplementedError()
 
+    def images_for_series(self, series_id, additional_tags=None, max_count=None):
+        """
+        :param series_id: SeriesInstanceUID from PACS
+        :param additional_tags:  List of additioanl DICOM tags to add to result datasets
+        :param max_count: if not None then limits the number of images returned
+        :return: list of image datasets
+        """
+        raise NotImplementedError()
+
     @abstractmethod
     def fetch_images_as_files(self, series_id):
         """
-        Fetches series images from PACS with C-GET
+        Fetches series images from PACS with C-MOVE
         :param series_id: SeriesInstanceUID from PACS
         :return: a path to a directory full of dicom files on success, None if not found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetch_image_as_file(self, series_id, sop_instance_id):
+        """
+        Fetches single series image from PACS with C-MOVE
+        :param series_id: SeriesInstanceUID from PACS
+        :param sop_instance_id: SOPInstanceUID from PACS
+        :return: a path to the dicom file on success, None if not found
         """
         raise NotImplementedError
 

--- a/pacsman/dicom_interface.py
+++ b/pacsman/dicom_interface.py
@@ -7,7 +7,6 @@ pacsman_private_tags = {
     0x00090010: ('LO', '1', 'Pacsman Private Identifier', '', 'PacsmanPrivateIdentifier'),
     0x00091001: ('CS', '1-N', "Study IDs for Patient", '', 'PatientStudyIDs'),
     0x00091002: ('DA', '1', 'Most Recent Study Date', '', 'PatientMostRecentStudyDate'),
-    0x00091003: ('UL', '1', "Number of Images in Series", '', 'NumberOfImagesInSeries'),
 }
 for tag in pacsman_private_tags:
     try:
@@ -92,7 +91,7 @@ class DicomInterface(ABC):
             Modality
             BodyPartExamined
             PatientPosition
-            NumberOfImagesInSeries (private tag)
+            NumberOfSeriesRelatedInstances
             Any valid DICOM tags in `additional_tags`
         """
         raise NotImplementedError()
@@ -107,7 +106,7 @@ class DicomInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def fetch_images_as_files(self, series_id):
+    def fetch_images_as_dicom_files(self, series_id):
         """
         Fetches series images from PACS with C-MOVE
         :param series_id: SeriesInstanceUID from PACS
@@ -116,7 +115,7 @@ class DicomInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def fetch_image_as_file(self, series_id, sop_instance_id):
+    def fetch_image_as_dicom_file(self, series_id, sop_instance_id):
         """
         Fetches single series image from PACS with C-MOVE
         :param series_id: SeriesInstanceUID from PACS

--- a/pacsman/filesystem_dev_client.py
+++ b/pacsman/filesystem_dev_client.py
@@ -141,14 +141,14 @@ class FilesystemDicomClient(DicomInterface):
                 break
         return image_datasets
 
-    def fetch_images_as_files(self, series_id):
+    def fetch_images_as_dicom_files(self, series_id):
         result_dir = os.path.join(self.dicom_dir, series_id)
         os.makedirs(result_dir, exist_ok=True)
         for (path, ds) in self.dicom_datasets.items():
             if ds.SeriesInstanceUID == series_id:
                 shutil.copy(path, os.path.join(result_dir))
 
-    def fetch_image_as_file(self, series_id, sop_instance_id):
+    def fetch_image_as_dicom_file(self, series_id, sop_instance_id):
         result_dir = os.path.join(self.dicom_dir, series_id)
         os.makedirs(result_dir, exist_ok=True)
         for (path, ds) in self.dicom_datasets.items():

--- a/pacsman/filesystem_dev_client.py
+++ b/pacsman/filesystem_dev_client.py
@@ -30,7 +30,7 @@ from pydicom import dcmread, Dataset
 from pydicom.valuerep import MultiValue
 
 from .dicom_interface import DicomInterface
-from .utils import process_and_write_png
+from .utils import process_and_write_png, copy_dicom_attributes
 
 logger = logging.getLogger(__name__)
 
@@ -73,12 +73,33 @@ class FilesystemDicomClient(DicomInterface):
 
                     ds.PacsmanPrivateIdentifier = 'pacsman'
                     ds.PatientMostRecentStudyDate = dataset.StudyDate
-                    for tag in additional_tags or []:
-                        setattr(ds, tag, getattr(dataset, tag))
+                    copy_dicom_attributes(ds, dataset, additional_tags)
 
                     patient_id_to_datasets[patient_id] = ds
 
         return list(patient_id_to_datasets.values())
+
+    def search_series(self, query_dataset, additional_tags=None):
+        # Build series-level datasets from the instance-level test data
+        additional_tags = additional_tags or []
+        result_datasets = []
+        for dataset in self.dicom_datasets.values():
+            series_matches = dataset.SeriesInstanceUID == query_dataset.SeriesInstanceUID
+            if series_matches:
+                ds = Dataset()
+                additional_tags += [
+                    'PatientName',
+                    'PatientBirthDate',
+                    'BodyPartExamined',
+                    'SeriesDescription',
+                    'PatientPosition',
+                ]
+                ds.PatientStudyIDs = MultiValue(str, [dataset.StudyInstanceUID])
+                ds.PacsmanPrivateIdentifier = 'pacsman'
+                ds.PatientMostRecentStudyDate = dataset.StudyDate
+                copy_dicom_attributes(ds, dataset, additional_tags)
+                result_datasets.append(ds)
+        return result_datasets
 
     def studies_for_patient(self, patient_id, additional_tags=None):
         # additional tags are ignored here; only tags available are already in the files
@@ -103,12 +124,22 @@ class FilesystemDicomClient(DicomInterface):
                 dataset.PatientPosition = getattr(dataset, 'PatientPosition', '')
                 series_id = dataset.SeriesInstanceUID
                 if series_id in series_id_to_dataset:
-                    series_id_to_dataset[series_id].NumberOfImagesInSeries += 1
+                    series_id_to_dataset[series_id].NumberOfSeriesRelatedInstances += 1
                 else:
-                    dataset.NumberOfImagesInSeries = 1
+                    dataset.NumberOfSeriesRelatedInstances = 1
                     series_id_to_dataset[series_id] = dataset
 
         return list(series_id_to_dataset.values())
+
+    def images_for_series(self, series_id, additional_tags=None, max_count=None):
+        image_datasets = []
+        for dataset in self.dicom_datasets.values():
+            series_matches = dataset.SeriesInstanceUID == series_id
+            if series_matches:
+                image_datasets.append(dataset)
+            if max_count and len(image_datasets) >= max_count:
+                break
+        return image_datasets
 
     def fetch_images_as_files(self, series_id):
         result_dir = os.path.join(self.dicom_dir, series_id)
@@ -116,6 +147,14 @@ class FilesystemDicomClient(DicomInterface):
         for (path, ds) in self.dicom_datasets.items():
             if ds.SeriesInstanceUID == series_id:
                 shutil.copy(path, os.path.join(result_dir))
+
+    def fetch_image_as_file(self, series_id, sop_instance_id):
+        result_dir = os.path.join(self.dicom_dir, series_id)
+        os.makedirs(result_dir, exist_ok=True)
+        for (path, ds) in self.dicom_datasets.items():
+            if ds.SOPInstanceUID == sop_instance_id:
+                return shutil.copy(path, os.path.join(result_dir))
+        return None
 
     def fetch_thumbnail(self, series_id):
         series_items = []

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -14,6 +14,11 @@ Steps to run integration tests:
 
 To explore or debug the remote data interactively, add www.dicomserver.co.uk:11112 as a
 location in Horos with any AETitle.
+
+If horos is running on a different machine set the LOCAL_PACS_URL environment variable to
+the ip of the machine running horos and similarly replace localhost in step
+3 of the instructions above.
+
 '''
 
 import logging

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -16,11 +16,13 @@ To explore or debug the remote data interactively, add www.dicomserver.co.uk:111
 location in Horos with any AETitle.
 '''
 
-import os
-import pytest
 import logging
-from .pynetdicom_client import PynetdicomClient
+import os
+
+import pytest
+
 from .filesystem_dev_client import FilesystemDicomClient
+from .pynetdicom_client import PynetdicomClient
 
 
 def initialize_pynetdicom_client(client_ae, pacs_url, pacs_port, dicom_dir):
@@ -37,6 +39,8 @@ def initialize_filesystem_client(dicom_dir, *args, **kwargs):
 
 dicom_client_initializers = [initialize_pynetdicom_client, initialize_filesystem_client]
 
+LOCAL_PACS_URL = os.environ.get('LOCAL_PACS_URL', 'localhost')
+
 
 @pytest.fixture(scope="module", params=dicom_client_initializers)
 def local_client(request):
@@ -47,7 +51,7 @@ def local_client(request):
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
     # local (Horos, all PAT014 data pulled from dicomserver.co.uk)
-    return request.param(client_ae='TEST', pacs_url='localhost',
+    return request.param(client_ae='TEST', pacs_url=LOCAL_PACS_URL,
                          pacs_port=11112, dicom_dir='.')
 
 
@@ -90,7 +94,7 @@ def test_local_series_for_study(local_client):
     assert len(series_datasets) > 1
     assert series_datasets[0]
     for ds in series_datasets:
-        assert ds.NumberOfImagesInSeries >= 1
+        assert ds.NumberOfSeriesRelatedInstances >= 1
         assert ds.InstitutionName
 
 

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -119,7 +119,7 @@ def test_local_studies_for_patient(local_client):
 def test_local_fetch(local_client, tmpdir):
     series_id = '1.2.826.0.1.3680043.6.51581.36765.20180518132103.25992.1.21'
     local_client.dicom_dir = str(tmpdir)
-    local_client.fetch_images_as_files(series_id)
+    local_client.fetch_images_as_dicom_files(series_id)
 
     series_dir = os.path.join(tmpdir, series_id)
     assert os.path.isdir(series_dir)
@@ -142,7 +142,7 @@ def test_local_fetch_thumbnail(local_client, tmpdir):
 def test_local_fetch_fail(local_client, tmpdir):
     series_id = 'nonexistentseriesID'
     local_client.dicom_dir = tmpdir
-    result_dir = local_client.fetch_images_as_files(series_id)
+    result_dir = local_client.fetch_images_as_dicom_files(series_id)
     thumbnail_file = local_client.fetch_thumbnail(series_id)
     assert result_dir is None
     assert thumbnail_file is None
@@ -182,4 +182,4 @@ def test_remote_fetch_fail(remote_client):
 
     # on dicomserver.co.uk, fails with 'Unknown Move Destination: TEST-SCP'
     with pytest.raises(Exception):
-        remote_client.fetch_images_as_files('1.2.826.0.1.3680043.6.79369.13951.20180518132058.25992.1.15')
+        remote_client.fetch_images_as_dicom_files('1.2.826.0.1.3680043.6.79369.13951.20180518132058.25992.1.15')

--- a/pacsman/utils.py
+++ b/pacsman/utils.py
@@ -52,3 +52,19 @@ def _pad_pixel_array_to_square(arr, pad_value=255):
     else:
         padding = ((0, b-a), (0, 0))
     return numpy.pad(arr, padding, mode='constant', constant_values=pad_value)
+
+def add_missing_blank_tags_to_dataset(dataset, additional_tags):
+    for tag in additional_tags or []:
+        if not hasattr(dataset, tag) or getattr(dataset, tag) is None:
+            setattr(dataset, tag, '')
+
+def copy_dicom_attributes(destination_dataset, source_dataset, additional_tags):
+    for tag in additional_tags or []:
+        setattr(destination_dataset, tag, dataset_attribute_fetcher(source_dataset, tag))
+
+def dataset_attribute_fetcher(dataset, data_attribute):
+    try:
+        return getattr(dataset, data_attribute)
+    except AttributeError:
+        # Dataset has a bug where it ignores the default=None when getattr is called.
+        return None

--- a/pacsman/utils.py
+++ b/pacsman/utils.py
@@ -48,19 +48,22 @@ def _pad_pixel_array_to_square(arr, pad_value=255):
     '''
     (a, b) = arr.shape
     if a > b:
-        padding = ((0, 0), (0, a-b))
+        padding = ((0, 0), (0, a - b))
     else:
-        padding = ((0, b-a), (0, 0))
+        padding = ((0, b - a), (0, 0))
     return numpy.pad(arr, padding, mode='constant', constant_values=pad_value)
 
-def add_missing_blank_tags_to_dataset(dataset, additional_tags):
+
+def set_undefined_tags_to_blank(dataset, additional_tags):
     for tag in additional_tags or []:
         if not hasattr(dataset, tag) or getattr(dataset, tag) is None:
             setattr(dataset, tag, '')
 
+
 def copy_dicom_attributes(destination_dataset, source_dataset, additional_tags):
     for tag in additional_tags or []:
         setattr(destination_dataset, tag, dataset_attribute_fetcher(source_dataset, tag))
+
 
 def dataset_attribute_fetcher(dataset, data_attribute):
     try:


### PR DESCRIPTION
Significant changes:
`NumberOfImagesInSeries` replaced by `NumberOfSeriesRelatedInstances`.
thumbnail fetcher returns full path, not just leaf name.
`StorageSCP` has method `path_for_dataset_instance`
New shared functions added to `utils.py`:
  *  `add_missing_blank_tags_to_dataset`
  *  `copy_dicom_attributes`
  *  `dataset_attribute_fetcher`
integration test can replace `localhost` with url found in environment