### PR TITLE
Fix empty attribute hazard

### DIFF
--- a/pacsman/filesystem_dev_client.py
+++ b/pacsman/filesystem_dev_client.py
@@ -147,6 +147,7 @@ class FilesystemDicomClient(DicomInterface):
         for (path, ds) in self.dicom_datasets.items():
             if ds.SeriesInstanceUID == series_id:
                 shutil.copy(path, os.path.join(result_dir))
+        return result_dir
 
     def fetch_image_as_dicom_file(self, series_id, sop_instance_id):
         result_dir = os.path.join(self.dicom_dir, series_id)

--- a/pacsman/utils.py
+++ b/pacsman/utils.py
@@ -62,7 +62,9 @@ def set_undefined_tags_to_blank(dataset, additional_tags):
 
 def copy_dicom_attributes(destination_dataset, source_dataset, additional_tags):
     for tag in additional_tags or []:
-        setattr(destination_dataset, tag, dataset_attribute_fetcher(source_dataset, tag))
+        value = dataset_attribute_fetcher(source_dataset, tag)
+        if value is not None:
+            setattr(destination_dataset, tag, value)
 
 
 def dataset_attribute_fetcher(dataset, data_attribute):

--- a/pacsman/utils_test.py
+++ b/pacsman/utils_test.py
@@ -29,6 +29,7 @@ def test_pad_png_pixel_array_pad_down():
     expected = np.array([[1, 1, 1], [2, 2, 2], [255, 255, 255]])
     assert np.array_equal(padded, expected)
 
+
 def test_copy_dicom_attributes():
     source_dataset = Dataset()
     destination_dataset = Dataset()

--- a/pacsman/utils_test.py
+++ b/pacsman/utils_test.py
@@ -1,6 +1,7 @@
 import numpy as np
+from pydicom import Dataset
 
-from .utils import _scale_pixel_array_to_uint8, _pad_pixel_array_to_square
+from .utils import _scale_pixel_array_to_uint8, _pad_pixel_array_to_square, copy_dicom_attributes
 
 
 def test_scale_pixel_array_to_png():
@@ -27,3 +28,11 @@ def test_pad_png_pixel_array_pad_down():
     padded = _pad_pixel_array_to_square(arr)
     expected = np.array([[1, 1, 1], [2, 2, 2], [255, 255, 255]])
     assert np.array_equal(padded, expected)
+
+def test_copy_dicom_attributes():
+    source_dataset = Dataset()
+    destination_dataset = Dataset()
+    destination_dataset.PatientName = 'Fred'
+    additional_tags = ['PatientName']
+    copy_dicom_attributes(destination_dataset, source_dataset, additional_tags)
+    assert destination_dataset.PatientName == 'Fred'


### PR DESCRIPTION
I hit a problem when trying to copy attributes from a source that did not exist.
I added a failing unit test, then fixed the problem.
In failure mode, the code hits an exception.
This is avoided by not trying to assign `None`.