### PR TITLE
Reassign dataset dictionary when adding datasets instead of mutating

### DIFF
--- a/pacsman/filesystem_dev_client.py
+++ b/pacsman/filesystem_dev_client.py
@@ -193,5 +193,8 @@ class FilesystemDicomClient(BaseDicomClient):
         :param datasets:
         :return:
         """
+        new_dicom_datasets = {}
         for dataset in datasets:
-            self._add_dataset(dataset)
+            filepath = self._filepath(dicom_filename(dataset))
+            new_dicom_datasets[filepath] = dataset
+        self.dicom_datasets = {**self.dicom_datasets, **new_dicom_datasets}


### PR DESCRIPTION
Dictionary iteration isn't subject to the GIL, so when `send_datasets` would add a report dataset to the `dicom_datasets` cache, the iterator would be invalidated and an exception would be thrown if any user was running a search or loading a page at the same time a report was added. 

Reassigning the dictionary does not seem to invalidate the old iterator. I tested this (and reproduced the original bug) by putting sleeps inside the `dicom_datasets` loops.