### PR TITLE
Add PACS destination override flags for send_dataset

### DIFF
--- a/pacsman/base_client.py
+++ b/pacsman/base_client.py
@@ -204,10 +204,14 @@ class BaseDicomClient(ABC):
                 result.PatientMostRecentStudyDate = study_date
 
     @abstractmethod
-    def send_datasets(self, datasets: Iterable[Dataset]) -> None:
+    def send_datasets(self, datasets: Iterable[Dataset], override_remote_ae: str = None,
+                      override_pacs_url: str = None, override_pacs_port: int = None) -> None:
         """
         Send a dicom dataset
-        :param datasets:
+        :param datasets: datasets to send
+        :param override_remote_ae: override this clients stored AE and send to different remote
+        :param override_pacs_url: conditionally required with override_remote_ae
+        :param override_pacs_port: conditionally required with override_remote_ae
         :return:
         """
         raise NotImplementedError

--- a/pacsman/filesystem_dev_client.py
+++ b/pacsman/filesystem_dev_client.py
@@ -227,12 +227,8 @@ class FilesystemDicomClient(BaseDicomClient):
         logger.warning(f'Could not find instance {instance_id} for series {series_id}')
         return None
 
-    def send_datasets(self, datasets: Iterable[Dataset]) -> None:
-        """
-        Send a dicom dataset
-        :param datasets:
-        :return:
-        """
+    def send_datasets(self, datasets: Iterable[Dataset], override_remote_ae: str = None,
+                      override_pacs_url: str = None, override_pacs_port: int = None) -> None:
         new_dicom_datasets = {}
         for dataset in datasets:
             filepath = self._filepath(dicom_filename(dataset))

--- a/pacsman/pynetdicom_client.py
+++ b/pacsman/pynetdicom_client.py
@@ -341,15 +341,20 @@ class PynetDicomClient(BaseDicomClient):
         png_path = process_and_write_png_from_file(dcm_path)
         return png_path
 
-    def send_datasets(self, datasets: Iterable[Dataset]) -> None:
-        """
-        Send dicom datasets
-        :param datasets:
-        :return:
-        """
+    def send_datasets(self, datasets: Iterable[Dataset], override_remote_ae: str = None,
+                      override_pacs_url: str = None, override_pacs_port: int = None) -> None:
+        if override_remote_ae is not None and override_pacs_url is not None and override_pacs_port is not None:
+            send_remote_ae = override_remote_ae
+            send_port = override_pacs_port
+            send_url = override_pacs_url
+        else:
+            send_remote_ae = self.remote_ae
+            send_port = self.pacs_port
+            send_url = self.pacs_url
+
         ae = AE(ae_title=self.client_ae)
         ae.requested_contexts = StoragePresentationContexts
-        with association(ae, self.pacs_url, self.pacs_port, self.remote_ae) as assoc:
+        with association(ae, send_url, send_port, send_remote_ae) as assoc:
             if assoc.is_established:
                 for dataset in datasets:
                     logger.info('Sending %s', dataset.SeriesInstanceUID)


### PR DESCRIPTION
It is common that a different remote AE is required for sending new datasets than the remote AE used for queries. Using separate PACS clients may introduce problems with starting more than one listener (or starting them out of order), particularly in `DcmtkDicomClient`. An AE override is added to `send_datasets`, the only method that has a C-MOVE SCU function. 