### PR TITLE
Start Using Orthanc in GitHub Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,12 +35,8 @@ jobs:
 
           # At this point, orthanc should be up - if not, halt
           python -m pynetdicom echoscu localhost $ORTHANC_PORT
-      # TODO, replace this with `upload_test.py`
       - name: Import Test DICOM Files
-        run: |
-          wget https://hg.orthanc-server.com/orthanc/raw-file/default/OrthancServer/Resources/Samples/ImportDicomFiles/ImportDicomFiles.py
-          python3 -m pip install httplib2
-          python3 ImportDicomFiles.py localhost 8042 ./pacsman/test_dicom_data
+        run: python3 pacsman/upload_test.py remote
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
         run: tox . --skip-missing-interpreters

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Start Orthanc
         run: docker-compose -f docker-compose.yml up -d orthanc
       - name: Install Tox and build dependencies
-        run: pip install tox
+        run: |
+          pip install .
+          pip install tox
       - name: Wait for Orthanc
         run: |
           ORTHANC_PORT=4242

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,30 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Start Orthanc
+        run: docker-compose -f docker-compose.yml up -d orthanc
       - name: Install Tox and build dependencies
         run: pip install tox
+      - name: Wait for Orthanc
+        run: |
+          ORTHANC_PORT=4242
+          MAX_ITERATIONS=60
+          ITERATIONS=0
+          until python -m pynetdicom echoscu localhost $ORTHANC_PORT > /dev/null 2>&1 || (($ITERATIONS >= $MAX_ITERATIONS)); do
+              >&2 echo "Waiting on Orthanc to be ready..."
+              ITERATIONS=$(( ITERATIONS + 1 ))
+              echo $ITERATIONS
+              sleep 1
+          done
+
+          # At this point, orthanc should be up - if not, halt
+          python -m pynetdicom echoscu localhost $ORTHANC_PORT
+      # TODO, replace this with `upload_test.py`
+      - name: Import Test DICOM Files
+        run: |
+          wget https://hg.orthanc-server.com/orthanc/raw-file/default/OrthancServer/Resources/Samples/ImportDicomFiles/ImportDicomFiles.py
+          python3 -m pip install httplib2
+          python3 ImportDicomFiles.py localhost 8042 ./pacsman/test_dicom_data
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
         run: tox . --skip-missing-interpreters

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Tests marked *remote* rely on a live DICOM server. For GitHub actions, an instan
 docker-compose up -d orthanc
 
 # If this is the first time, and test data files have not yet been loaded
-python3 -m pip install httplib2
-python3 ./vendor/ImportDicomFiles.py localhost 8042 ./pacsman/test_dicom_data
+python3 pacsman/upload_test.py remote
 
 # If you have DCMTK installed, here is a quick test
 echoscu localhost 4242

--- a/README.md
+++ b/README.md
@@ -17,3 +17,28 @@ files.
 In addition to the supplied backends, you can write your own backend implementing the
 `BaseDicomClient`. This can be a useful interface layer for non-PACS systems such as a
 cloud storage system.
+
+## Development
+Linting is done with `flake8` and testing with `pytest`.
+
+GitHub actions has automatic checks for both linting and tests, using [`tox`](https://tox.wiki/en/latest/) as the runner (see [`./tox.ini`](tox.ini)). To replicate this locally, install `tox`, then run `tox .` in the root of the project.
+
+> If you get an error about "InterpreterNotFound", make sure you have that version of Python installed and in the path (e.g., discoverable with `which python{version}`). Or use `--skip-missing-interpreters` to skip those.
+
+
+### Remote DICOM Testing - Using Orthanc
+Tests marked *remote* rely on a live DICOM server. For GitHub actions, an instance of Orthanc will be used, and you can re-use this service locally as well.
+
+```bash
+docker-compose up -d orthanc
+
+# If this is the first time, and test data files have not yet been loaded
+python3 -m pip install httplib2
+python3 ./vendor/ImportDicomFiles.py localhost 8042 ./pacsman/test_dicom_data
+
+# If you have DCMTK installed, here is a quick test
+echoscu localhost 4242
+
+# Or, with pynetdicom
+python -m pynetdicom echoscu localhost 4242
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# For use with GitHub Actions, or for local testing
+# https://book.orthanc-server.com/users/docker-osimis.html
+# Legacy docs: https://osimis.atlassian.net/wiki/spaces/OKB/pages/26738689/How+to+use+osimis+orthanc+Docker+images (some of these settings are still used)
+version: '3'
+services:
+  orthanc:
+    image: osimis/orthanc:22.6.2
+    restart: unless-stopped
+    ports:
+      # For local testing, if you want to poke around the web interface
+      - "8042:8042"
+      # DICOM port
+      # If we ever dockerize the entire repo, then host-binding like this would not be necessary, and we could move to
+      # using `orthanc:4242`
+      - "4242:4242"
+    environment:
+      # This is the default value, just documenting
+      DICOM_AET: "ORTHANC"
+      # Syntax is [AET, Address, Port, optional_Vendor_Patch]
+      DICOM_MODALITIES: |
+        {
+          "testing": [ "TEST", "localhost", 4242 ]
+        }
+      AC_AUTHENTICATION_ENABLED: "false"
+      VERBOSE_ENABLED: "true"
+    volumes:
+      - "orthanc-storage-volume:/var/lib/orthanc/db"
+volumes:
+  orthanc-storage-volume:

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -1,5 +1,5 @@
 '''
-Remote tests depend on data from www.dicomserver.co.uk. The data there could change.
+Remote tests depend on a running Orthanc instance (emulating a remote server).
 No data is fetched from the remote server because C-GET is not yet supported in pacsman.
 
 Local tests depend on data in the `test_dicom_dir` directory, which is imported into a local
@@ -13,9 +13,6 @@ Steps to run integration tests:
  4) `pytest integration_test.py` or `pytest -m local integration_test.py` for local-only
 
 An alternative to step 2 above is to run upload_test.py
-
-To explore or debug the remote data interactively, add www.dicomserver.co.uk:11112 as a
-location in Horos with any AETitle.
 
 If horos is running on a different machine set the LOCAL_PACS_URL environment variable to
 the ip of the machine running horos and similarly replace localhost in step
@@ -33,7 +30,7 @@ from .pynetdicom_client import PynetDicomClient
 
 
 def initialize_pynetdicom_client(client_ae, pacs_url, pacs_port, dicom_dir):
-    return PynetDicomClient(client_ae=client_ae, remote_ae='TEST', pacs_url=pacs_url, pacs_port=pacs_port,
+    return PynetDicomClient(client_ae=client_ae, remote_ae='ORTHANC', pacs_url=pacs_url, pacs_port=pacs_port,
                             dicom_dir=dicom_dir)
 
 
@@ -70,8 +67,8 @@ def remote_client(request):
     logger.setLevel(logging.DEBUG)
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
-    return request.param(client_ae='TEST', pacs_url='www.dicomserver.co.uk',
-                         pacs_port=11112, dicom_dir='.')
+    return request.param(client_ae='TEST', pacs_url='localhost',
+                         pacs_port=4242, dicom_dir='.')
 
 
 @pytest.mark.integration

--- a/pacsman/upload_test.py
+++ b/pacsman/upload_test.py
@@ -1,24 +1,32 @@
 import os
+import argparse
 
-from pacsman import DcmtkDicomClient, PynetDicomClient
+from pacsman import PynetDicomClient
 from pacsman import dicom_file_iterator
 
 TEST_DATA_DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_dicom_data')
 LOCAL_PACS_URL = os.environ.get('LOCAL_PACS_URL', 'localhost')
 
 
-def main():
+def main(destination='both'):
     print(f'uploading test data from {TEST_DATA_DIRECTORY}')
 
-    # "TEST" must be registered AE in the Horos listener
-    client = DcmtkDicomClient(client_ae='TEST', pacs_url=LOCAL_PACS_URL, pacs_port=11112,
-                              dicom_dir='.', remote_ae='HOROS-LOCAL')
-    client.send_datasets(dicom_file_iterator(TEST_DATA_DIRECTORY))
+    if destination == 'both' or destination == 'remote':
+        print('Uploading files to remote destination')
+        client = PynetDicomClient(client_ae='TEST', pacs_url=LOCAL_PACS_URL, pacs_port=4242,
+                                  dicom_dir='.', remote_ae='ORTHANC')
+        client.send_datasets(dicom_file_iterator(TEST_DATA_DIRECTORY))
 
-    client = PynetDicomClient(client_ae='TEST', pacs_url=LOCAL_PACS_URL, pacs_port=11112,
-                              dicom_dir='.', remote_ae='HOROS-LOCAL')
-    client.send_datasets(dicom_file_iterator(TEST_DATA_DIRECTORY))
+    if destination == 'both' or destination == 'local':
+        print('Uploading files to local destination')
+        # "TEST" must be registered AE in the Horos listener
+        client = PynetDicomClient(client_ae='TEST', pacs_url=LOCAL_PACS_URL, pacs_port=11112,
+                                  dicom_dir='.', remote_ae='HOROS-LOCAL')
+        client.send_datasets(dicom_file_iterator(TEST_DATA_DIRECTORY))
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('destination', choices=['both', 'remote', 'local'], default='both', nargs='?')
+    args = parser.parse_args()
+    main(destination=args.destination)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    remote: mark a test as depending on remote data (using Orthanc)
+    local: mark a test as depending on local data (`test_dicom_dir`), imported into a local Horos instance
+    integration: mark a test as being an integration test


### PR DESCRIPTION
Closes #40 

Some notes:

- Started this branch off with a completely empty commit, just so anyone that is interested can see the CI failure
- There might be some future low hanging fruit for future CI optimizations (e.g. deps reuse from outside tox), but I didn't want to delay this much more than it needed to be
- Added some quick notes to the README on developing pacsman
- Added explicit `pytest.ini` with marks registration (there were a lot of warnings about unregistered marks cluttering the log output)

Improving the `integration` tests that rely on Horos and getting those to run on CI would also be nice future work.