### PR TITLE
DCMTK TImeouts - Add Retry with Padding / Backoff

### DIFF
--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -39,7 +39,7 @@ dcmtk_error_codes = {
 """
 This is a partial list of DCMTK error code constants, separated by module.
 
-Codes are printed in stdout as a pair of module code + error code, e.g. `0006:0207`
+Codes are printed as a pair of module code + error code, e.g. `0006:0207`
 
 Module codes are defined in `dcerror.h`.
 https://github.com/DCMTK/dcmtk/blob/31ae87d57edf3f5a441cae64869c7337b29213b2/dcmdata/include/dcmtk/dcmdata/dcerror.h#L36-L75
@@ -545,7 +545,7 @@ def _check_dcmtk_message_for_error(dcmtk_message: str) -> Optional[Tuple[int, in
 
     This is a known issue: https://support.dcmtk.org/redmine/issues/929
     """
-    # Standard pattern is E: (0x0001, 0x0002) ERROR MESSAGE
+    # Standard pattern is E: 0001:0002 ERROR MESSAGE
     pattern = re.compile(r"[EF]: ([\da-f]{4}:[\da-f]{4}) [^#\r\n]+$", flags=re.MULTILINE)
 
     # Only check last three lines, and in reverse order (last first)

--- a/pacsman/dcmtk_client_test.py
+++ b/pacsman/dcmtk_client_test.py
@@ -1,0 +1,76 @@
+from .dcmtk_client import _check_stdout_for_error
+
+
+def test_stdout_error_checking():
+    # Standard message, with error
+    test_string = '''
+D: ======================= END DIMSE MESSAGE =======================
+I: Request Identifiers:
+I: 
+I: # Dicom-Data-Set
+I: # Used TransferSyntax: Little Endian Implicit
+I: (0008,0020) DA (no value available)                     #   0, 0 StudyDate
+I: (0008,0052) CS [STUDY ]                                 #   6, 1 QueryRetrieveLevel
+I: (0010,0010) PN (no value available)                     #   0, 0 PatientName
+I: (0010,0020) LO [snipped]                                #  10, 1 PatientID
+I: (0010,0030) DA (no value available)                     #   0, 0 PatientBirthDate
+I: (0010,0040) CS (no value available)                     #   0, 0 PatientSex
+I: (0020,000d) UI (no value available)                     #   0, 0 StudyInstanceUID
+I: 
+E: Find Failed, file: /tmp/tmp5ld6qp8a/find_input.dcm:
+E: 0006:0207 DIMSE No data available (timeout in non-blocking mode)
+E: Find SCU Failed: 0006:0207 DIMSE No data available (timeout in non-blocking mode)
+I: Aborting Association''' # noqa
+    assert(_check_stdout_for_error(test_string) == (0x0006, 0x0207))
+
+    # Another error message
+    test_string = '''
+F: Association Request Failed: 0006:031b Failed to establish association
+F: 0006:0317 Peer aborted Association (or never connected)
+F: 0006:031c TCP Initialization Error: Connection refused'''
+    assert(_check_stdout_for_error(test_string) == (0x006, 0x031c))
+
+    # echoscu, no errors, verbose
+    test_string = '''
+I: Requesting Association
+I: Association Accepted (Max Send PDV: 16372)
+I: Sending Echo Request (MsgID 1)
+I: Received Echo Response (Success)
+I: Releasing Association
+    '''
+    assert(_check_stdout_for_error(test_string) is None)
+
+    # Successful findscu, empty, verbose
+    test_string = '''
+I: Requesting Association
+I: Association Accepted (Max Send PDV: 16372)
+I: Sending Find Request (MsgID 1)
+I: Request Identifiers:
+I: 
+I: # Dicom-Data-Set
+I: # Used TransferSyntax: Little Endian Explicit
+I: (0008,0052) CS [STUDY]                                  #   6, 1 QueryRetrieveLevel
+I: (0008,103e) LO (no value available)                     #   0, 0 SeriesDescription
+I: (0010,0010) PN [TEST]                                   #   4, 1 PatientName
+I: 
+I: Received Final Find Response (Success)
+I: Releasing Association''' # noqa
+
+    # Successful findscu, has results, non-verbose
+    test_string = '''
+I: ---------------------------
+I: Find Response: 1 (Pending)
+I: 
+I: # Dicom-Data-Set
+I: # Used TransferSyntax: Little Endian Explicit
+I: (0008,0005) CS [ISO_IR 100]                             #  10, 1 SpecificCharacterSet
+I: (0008,0052) CS [STUDY ]                                 #   6, 1 QueryRetrieveLevel
+I: (0008,0054) AE [ORTHANC ]                               #   8, 1 RetrieveAETitle
+I: (0008,103e) LO (no value available)                     #   0, 0 SeriesDescription
+I: (0010,0010) PN [Lymphoma]                               #   8, 1 PatientName
+I: 
+I: ''' # noqa
+    assert(_check_stdout_for_error(test_string) is None)
+
+    # Handling an empty stdout
+    assert(_check_stdout_for_error('') is None)

--- a/pacsman/dcmtk_client_test.py
+++ b/pacsman/dcmtk_client_test.py
@@ -1,4 +1,4 @@
-from .dcmtk_client import _check_stdout_for_error
+from .dcmtk_client import _check_dcmtk_message_for_error
 
 
 def test_stdout_error_checking():
@@ -21,14 +21,14 @@ E: Find Failed, file: /tmp/tmp5ld6qp8a/find_input.dcm:
 E: 0006:0207 DIMSE No data available (timeout in non-blocking mode)
 E: Find SCU Failed: 0006:0207 DIMSE No data available (timeout in non-blocking mode)
 I: Aborting Association''' # noqa
-    assert(_check_stdout_for_error(test_string) == (0x0006, 0x0207))
+    assert(_check_dcmtk_message_for_error(test_string) == (0x0006, 0x0207))
 
     # Another error message
     test_string = '''
 F: Association Request Failed: 0006:031b Failed to establish association
 F: 0006:0317 Peer aborted Association (or never connected)
 F: 0006:031c TCP Initialization Error: Connection refused'''
-    assert(_check_stdout_for_error(test_string) == (0x006, 0x031c))
+    assert(_check_dcmtk_message_for_error(test_string) == (0x006, 0x031c))
 
     # echoscu, no errors, verbose
     test_string = '''
@@ -38,7 +38,7 @@ I: Sending Echo Request (MsgID 1)
 I: Received Echo Response (Success)
 I: Releasing Association
     '''
-    assert(_check_stdout_for_error(test_string) is None)
+    assert(_check_dcmtk_message_for_error(test_string) is None)
 
     # Successful findscu, empty, verbose
     test_string = '''
@@ -70,7 +70,7 @@ I: (0008,103e) LO (no value available)                     #   0, 0 SeriesDescri
 I: (0010,0010) PN [Lymphoma]                               #   8, 1 PatientName
 I: 
 I: ''' # noqa
-    assert(_check_stdout_for_error(test_string) is None)
+    assert(_check_dcmtk_message_for_error(test_string) is None)
 
     # Handling an empty stdout
-    assert(_check_stdout_for_error('') is None)
+    assert(_check_dcmtk_message_for_error('') is None)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ description = 'pacsman: Picture Archiving and Communication System Manager And N
 
 setup(
     name='pacsman',
-    version='0.1.0',
+    version='0.1.1',
     description=description,
     long_description=description,
     url='https://github.com/innolitics/pacsman',


### PR DESCRIPTION
Thank you for writing up the instructions for injecting the Python plugin into Orthan and our chats on this.

Hopefully this is the direction you were thinking. The main option to toggle this on / off is the last argument to the class constructor, so the signature shouldn't change for any consumers (and default is `False` / off).