### PR TITLE
Add search_query_type to search_patients

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
           # At this point, orthanc should be up - if not, halt
           python -m pynetdicom echoscu localhost $ORTHANC_PORT
-      - name: Install DCMKT
+      - name: Install DCMTK
         run: |
           sudo apt update
           sudo apt install dcmtk

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,6 +35,10 @@ jobs:
 
           # At this point, orthanc should be up - if not, halt
           python -m pynetdicom echoscu localhost $ORTHANC_PORT
+      - name: Install DCMKT
+        run: |
+          sudo apt update
+          sudo apt install dcmtk
       - name: Import Test DICOM Files
         run: python3 pacsman/upload_test.py remote
       - name: Run Tox

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,9 @@ name: Unit tests
 
 on: [push]
 
+env:
+  DCMDICTPATH: "../etc/dcmtk/dicom.dic"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,9 +2,6 @@ name: Unit tests
 
 on: [push]
 
-env:
-  DCMDICTPATH: "../etc/dcmtk/dicom.dic"
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Linting is done with `flake8` and testing with `pytest`.
 
 GitHub actions has automatic checks for both linting and tests, using [`tox`](https://tox.wiki/en/latest/) as the runner (see [`./tox.ini`](tox.ini)). To replicate this locally, install `tox`, then run `tox .` in the root of the project.
 
+> If you get an error about `DCMDICTPATH` or `SCPCFGPATH` not being found, change the `tox.ini` setenv values to your local path to the referenced files. 
+
 > If you get an error about "InterpreterNotFound", make sure you have that version of Python installed and in the path (e.g., discoverable with `which python{version}`). Or use `--skip-missing-interpreters` to skip those.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # For use with GitHub Actions, or for local testing
 # https://book.orthanc-server.com/users/docker-osimis.html
 # Legacy docs: https://osimis.atlassian.net/wiki/spaces/OKB/pages/26738689/How+to+use+osimis+orthanc+Docker+images (some of these settings are still used)
-version: '3'
+version: "3"
 services:
   orthanc:
     image: osimis/orthanc:22.6.2
@@ -23,6 +23,7 @@ services:
         }
       AC_AUTHENTICATION_ENABLED: "false"
       VERBOSE_ENABLED: "true"
+      DCMDICTPATH: "/usr/local/Cellar/dcmtk/3.6.6/share/dcmtk/dicom.dic"
     volumes:
       - "orthanc-storage-volume:/var/lib/orthanc/db"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
         }
       AC_AUTHENTICATION_ENABLED: "false"
       VERBOSE_ENABLED: "true"
-      DCMDICTPATH: "/usr/local/Cellar/dcmtk/3.6.6/share/dcmtk/dicom.dic"
     volumes:
       - "orthanc-storage-volume:/var/lib/orthanc/db"
 volumes:

--- a/pacsman/base_client.py
+++ b/pacsman/base_client.py
@@ -42,14 +42,19 @@ class BaseDicomClient(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def search_patients(self, search_query: str, additional_tags: List[str] = None,
+    def search_patients(self, search_query: Optional[str] = None,
+                        search_query_type: Optional[str] = None,
+                        additional_tags: Optional[List[str]] = None,
                         wildcard: bool = True) -> List[Dataset]:
         """
         Search for patients. The PatientID and PatientName are searched.
-        Performs a partial match.
-        :param search_query: Search string for either patient name or ID
+        Performs a partial match if wildcard is True.
+        :param search_query: String containing query value to c_find.
+        :param search_query_type: Optional string that restricts patient search to 'PatientID' or 'PatientName'.
+            If None, perform a C-FIND for the query once on PatientID and again on PatientName.
         :param additional_tags: additional DICOM tags for result datasets
-        :param wildcard: whether to add wildcards to search string, defaults to True
+        :param wildcard: Boolean stating whether to search partial matches (i.e. Sam would find Samuel).
+            Defaults to True.
         :return: List of patient-Level pydicom Datasets, with tags:
             PatientName
             PatientID

--- a/pacsman/base_client.py
+++ b/pacsman/base_client.py
@@ -43,15 +43,12 @@ class BaseDicomClient(ABC):
 
     @abstractmethod
     def search_patients(self, search_query: Optional[str] = None,
-                        search_query_type: Optional[str] = None,
                         additional_tags: Optional[List[str]] = None,
                         wildcard: bool = True) -> List[Dataset]:
         """
         Search for patients. The PatientID and PatientName are searched.
         Performs a partial match if wildcard is True.
         :param search_query: String containing query value to c_find.
-        :param search_query_type: Optional string that restricts patient search to 'PatientID' or 'PatientName'.
-            If None, perform a C-FIND for the query once on PatientID and again on PatientName.
         :param additional_tags: additional DICOM tags for result datasets
         :param wildcard: Boolean stating whether to search partial matches (i.e. Sam would find Samuel).
             Defaults to True.

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -297,7 +297,7 @@ class DcmtkDicomClient(BaseDicomClient):
         return list(patient_id_to_datasets.values())
 
     def _search_patient_with_dataset(self, search_dataset: Dataset,
-                                    patient_id_to_datasets: defaultdict[str, Dataset],
+                                    patient_id_to_datasets: defaultdict,
                                     additional_tags: Optional[List[str]] = None):
         '''
         This function does not return any values but rather modifies the patient_id_to_datasets argument in-place.

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -17,7 +17,7 @@ import threading
 import glob
 from collections import defaultdict
 
-from typing import List, Optional, Iterable, Tuple, Literal
+from typing import List, Optional, Iterable, Tuple
 
 import pydicom
 from pydicom import dcmread
@@ -137,8 +137,7 @@ class DcmtkDicomClient(BaseDicomClient):
             storescp_config_path = os.environ['SCPCFGPATH']
         else:
             # fallback path typical to some dcmtk installations
-            storescp_config_path = os.path.join(dcm_dict_dir,
-                                                '../../etc/dcmtk/storescp.cfg')
+            storescp_config_path = os.path.join(dcm_dict_dir, '../../etc/dcmtk/storescp.cfg')
 
         # TODO storescp logging is going to stdout: should have self.logger redirect
         storescp_args = ['storescp', '--fork', '--aetitle', client_ae,
@@ -268,7 +267,7 @@ class DcmtkDicomClient(BaseDicomClient):
             return True
 
     def search_patients(self, search_query: Optional[str] = None,
-                        search_query_type: Optional[Literal['PatientID', 'PatientName', None]] = None,
+                        search_query_type: Optional[str] = None,
                         additional_tags: Optional[List[str]] = None,
                         wildcard: bool = True) -> List[Dataset]:
         '''

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -297,8 +297,8 @@ class DcmtkDicomClient(BaseDicomClient):
         return list(patient_id_to_datasets.values())
 
     def _search_patient_with_dataset(self, search_dataset: Dataset,
-                                    patient_id_to_datasets: defaultdict,
-                                    additional_tags: Optional[List[str]] = None):
+                                     patient_id_to_datasets: defaultdict,
+                                     additional_tags: Optional[List[str]] = None):
         '''
         This function does not return any values but rather modifies the patient_id_to_datasets argument in-place.
         '''

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -137,7 +137,7 @@ class DcmtkDicomClient(BaseDicomClient):
             storescp_config_path = os.environ['SCPCFGPATH']
         else:
             # fallback path typical to some dcmtk installations
-            storescp_config_path = os.path.join(dcm_dict_dir, 'storescp.cfg')  # '../../etc/dcmtk/storescp.cfg')
+            storescp_config_path = os.path.join(dcm_dict_dir, '../../etc/dcmtk/storescp.cfg')
 
         # TODO storescp logging is going to stdout: should have self.logger redirect
         storescp_args = ['storescp', '--fork', '--aetitle', client_ae,

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -137,7 +137,7 @@ class DcmtkDicomClient(BaseDicomClient):
             storescp_config_path = os.environ['SCPCFGPATH']
         else:
             # fallback path typical to some dcmtk installations
-            storescp_config_path = os.path.join(dcm_dict_dir, '../../etc/dcmtk/storescp.cfg')
+            storescp_config_path = os.path.join(dcm_dict_dir,'storescp.cfg')  # '../../etc/dcmtk/storescp.cfg')
 
         # TODO storescp logging is going to stdout: should have self.logger redirect
         storescp_args = ['storescp', '--fork', '--aetitle', client_ae,

--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -137,7 +137,7 @@ class DcmtkDicomClient(BaseDicomClient):
             storescp_config_path = os.environ['SCPCFGPATH']
         else:
             # fallback path typical to some dcmtk installations
-            storescp_config_path = os.path.join(dcm_dict_dir,'storescp.cfg')  # '../../etc/dcmtk/storescp.cfg')
+            storescp_config_path = os.path.join(dcm_dict_dir, 'storescp.cfg')  # '../../etc/dcmtk/storescp.cfg')
 
         # TODO storescp logging is going to stdout: should have self.logger redirect
         storescp_args = ['storescp', '--fork', '--aetitle', client_ae,

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -117,15 +117,15 @@ def test_local_patient_search(dcmtk_client, c_find_mock):
     c_find_mock.reset_mock()
 
     dcmtk_client.search_patients(search_query='PAT014',
-                                search_query_type='PatientID',
-                                wildcard=False)
+                                 search_query_type='PatientID',
+                                 wildcard=False)
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
     c_find_mock.reset_mock()
 
     dcmtk_client.search_patients(search_query='PAT014',
-                                search_query_type='PatientName',
-                                wildcard=False)
+                                 search_query_type='PatientName',
+                                 wildcard=False)
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
 

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -117,15 +117,15 @@ def test_local_patient_search(dcmtk_client, c_find_mock):
     c_find_mock.reset_mock()
 
     dcmtk_client.search_patients(search_query='PAT014',
-                                    search_query_type='PatientID',
-                                    wildcard=False)
+                                search_query_type='PatientID',
+                                wildcard=False)
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
     c_find_mock.reset_mock()
 
     dcmtk_client.search_patients(search_query='PAT014',
-                                    search_query_type='PatientName',
-                                    wildcard=False)
+                                search_query_type='PatientName',
+                                wildcard=False)
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
 

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -44,9 +44,9 @@ def initialize_filesystem_client(dicom_dir, *args, **kwargs):
 
 
 def initialize_dcmtk_client(client_ae, pacs_url, pacs_port, dicom_dir):
-    return DcmtkDicomClient(client_ae=client_ae, 
-                            remote_ae='ORTHANC', 
-                            pacs_url=pacs_url, 
+    return DcmtkDicomClient(client_ae=client_ae,
+                            remote_ae='ORTHANC',
+                            pacs_url=pacs_url,
                             pacs_port=pacs_port,
                             dicom_dir=dicom_dir)
 
@@ -106,28 +106,28 @@ def test_verify_c_echo(local_client):
 @pytest.mark.integration
 @pytest.mark.remote
 def test_local_patient_search(dcmtk_client, c_find_mock):
-        patient_datasets = dcmtk_client.search_patients(search_query='PAT014', 
-                                                        additional_tags=['PatientSex'])
-        assert len(patient_datasets) == 1
-        assert len(patient_datasets[0].PatientStudyInstanceUIDs) > 1
-        assert patient_datasets[0].PatientMostRecentStudyDate
-        assert patient_datasets[0].PatientSex == 'F'
-        # assert c_find got called 2x, once for PatientID and once for PatientName
-        assert c_find_mock.call_count == 2
-        c_find_mock.reset_mock()
+    patient_datasets = dcmtk_client.search_patients(search_query='PAT014',
+                                                    additional_tags=['PatientSex'])
+    assert len(patient_datasets) == 1
+    assert len(patient_datasets[0].PatientStudyInstanceUIDs) > 1
+    assert patient_datasets[0].PatientMostRecentStudyDate
+    assert patient_datasets[0].PatientSex == 'F'
+    # assert c_find got called 2x, once for PatientID and once for PatientName
+    assert c_find_mock.call_count == 2
+    c_find_mock.reset_mock()
 
-        dcmtk_client.search_patients(search_query='PAT014',
-                                     search_query_type='PatientID',
-                                     wildcard=False)
-        # assert c_find only got called 1x
-        c_find_mock.assert_called_once()
-        c_find_mock.reset_mock()
+    dcmtk_client.search_patients(search_query='PAT014',
+                                    search_query_type='PatientID',
+                                    wildcard=False)
+    # assert c_find only got called 1x
+    c_find_mock.assert_called_once()
+    c_find_mock.reset_mock()
 
-        dcmtk_client.search_patients(search_query='PAT014',
-                                     search_query_type='PatientName',
-                                     wildcard=False)
-        # assert c_find only got called 1x
-        c_find_mock.assert_called_once()
+    dcmtk_client.search_patients(search_query='PAT014',
+                                    search_query_type='PatientName',
+                                    wildcard=False)
+    # assert c_find only got called 1x
+    c_find_mock.assert_called_once()
 
 
 @pytest.mark.integration

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ description = 'pacsman: Picture Archiving and Communication System Manager And N
 
 setup(
     name='pacsman',
-    version='0.1.1',
+    version='0.1.2',
     description=description,
     long_description=description,
     url='https://github.com/innolitics/pacsman',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py3{7,8,9}-pynetdicom2
 
 [testenv]
 setenv = 
-    DCMDICTPATH = /usr/share/libdcmtk15/dicom.dic
+    DCMDICTPATH = /usr/share/libdcmtk14/dicom.dic
     SCPCFGPATH = /etc/dcmtk/storescp.cfg
 extras = test
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py3{7,8,9}-pynetdicom2
 
 [testenv]
 setenv = 
-    DCMDICTPATH = {toxinidir}/etc/dcmtk/dicom.dic
-    SCPCFGPATH = {toxinidir}/etc/dcmtk/storescp.cfg
+    DCMDICTPATH = /usr/share/libdcmtk15/dicom.dic
+    SCPCFGPATH = /etc/dcmtk/storescp.cfg
 extras = test
 basepython =
     py37: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py3{7,8,9}-pynetdicom2
 
 [testenv]
+setenv = DCMDICTPATH = {toxinidir}/etc/dcmtk/dicom.dic
 extras = test
 basepython =
     py37: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py3{7,8,9}-pynetdicom2
 
 [testenv]
-setenv = DCMDICTPATH = {toxinidir}/etc/dcmtk/dicom.dic
+setenv = 
+    DCMDICTPATH = {toxinidir}/etc/dcmtk/dicom.dic
+    SCPCFGPATH = {toxinidir}/etc/dcmtk/storescp.cfg
 extras = test
 basepython =
     py37: python3.7


### PR DESCRIPTION
Allows users to specify a search_query_type parameter as part of DcmtkDicomClient.search_patients()
- If search_query_type is 'PatientName' the c_find will only be performed against the PatientName attribute.
- If search_query_type is 'PatientID' the c_find will only be performed against the PatientID attribute.
- If search_query_type is any other value, including None (the default) it will search against PatientName and PatientID, the same way it always has. 
