### PR TITLE
Properly search for patient names in default search query mode

### DIFF
--- a/pacsman/dcmtk_client.py
+++ b/pacsman/dcmtk_client.py
@@ -288,8 +288,10 @@ class DcmtkDicomClient(BaseDicomClient):
         search_dataset = self._get_study_search_dataset()
         if search_query_type == 'PatientID' or search_query_type is None:
             search_dataset.PatientID = search_query
+            search_dataset.PatientName = ""
             self._search_patient_with_dataset(search_dataset, patient_id_to_datasets, additional_tags)
         if search_query_type == 'PatientName' or search_query_type is None:
+            search_dataset.PatientID = ""
             search_dataset.PatientName = search_query
             self._search_patient_with_dataset(search_dataset, patient_id_to_datasets, additional_tags)
 

--- a/pacsman/integration_test.py
+++ b/pacsman/integration_test.py
@@ -115,20 +115,43 @@ def test_local_patient_search(dcmtk_client, c_find_mock):
     assert patient_datasets[0].PatientSex == 'F'
     # assert c_find got called 2x, once for PatientID and once for PatientName
     assert c_find_mock.call_count == 2
+
+    # Patient name search should also succeed by default
+    patient_datasets = dcmtk_client.search_patients(
+        search_query='Richardson',
+        wildcard=True
+    )
+    assert len(patient_datasets) == 1
+
     c_find_mock.reset_mock()
 
-    dcmtk_client.search_patients(search_query='PAT014',
-                                 search_query_type='PatientID',
-                                 wildcard=False)
+    patient_datasets = dcmtk_client.search_patients(
+        search_query='PAT014',
+        search_query_type='PatientID',
+        wildcard=False,
+    )
+    assert len(patient_datasets) == 1
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
     c_find_mock.reset_mock()
 
-    dcmtk_client.search_patients(search_query='PAT014',
-                                 search_query_type='PatientName',
-                                 wildcard=False)
+    # Patient name should not return results for PAT014
+    patient_datasets = dcmtk_client.search_patients(
+        search_query='PAT014',
+        search_query_type='PatientName',
+        wildcard=False,
+    )
     # assert c_find only got called 1x
     c_find_mock.assert_called_once()
+    assert len(patient_datasets) == 0
+
+    # Patient name search should succeed
+    patient_datasets = dcmtk_client.search_patients(
+        search_query='Richardson',
+        search_query_type='PatientName',
+        wildcard=True,
+    )
+    assert len(patient_datasets) == 1
 
 
 @pytest.mark.integration

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ description = 'pacsman: Picture Archiving and Communication System Manager And N
 
 setup(
     name='pacsman',
-    version='0.1.4',
+    version='0.1.5',
     description=description,
     long_description=description,
     url='https://github.com/innolitics/pacsman',


### PR DESCRIPTION
A bug was introduced where searching for a patient using the default method (two C-FINDs, one for patient ID and another for patient name) would result in patient name searches not being performed correctly. This is because the PatientID attribute was never cleared from the search dataset, thus incorrectly limiting results.

This bug was fixed, along with expanding the test case for patient search to exercise this case.